### PR TITLE
added ldap_user_ssh_public_key attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Attributes
 | ['max_id'] | '0' | default, used to ignore higher uid/gid's |
 | ['ldap_sudo'] | false | Adds ldap enabled sudoers (true/false) |
 | ['ldap_ssh'] | false | Adds ldap enabled ssh (true/false) |
+| ['ldap_user_ssh_public_key'] | nil | ldap attribute containing ssh public key |
 
 
 Recipes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,3 +56,5 @@ default['sssd_ldap']['ldap_sudo'] = false
 default['sssd_ldap']['ldap_ssh'] = false
 
 default['sssd_ldap']['ldap_user_ssh_public_key'] = nil
+
+default['sssd_ldap']['domains'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,5 +56,3 @@ default['sssd_ldap']['ldap_sudo'] = false
 default['sssd_ldap']['ldap_ssh'] = false
 
 default['sssd_ldap']['ldap_user_ssh_public_key'] = nil
-
-default['sssd_ldap']['domains'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,3 +54,5 @@ default['sssd_ldap']['min_id'] = '1'
 default['sssd_ldap']['max_id'] = '0'
 default['sssd_ldap']['ldap_sudo'] = false
 default['sssd_ldap']['ldap_ssh'] = false
+
+default['sssd_ldap']['ldap_user_ssh_public_key'] = nil

--- a/files/default/mkhomedir
+++ b/files/default/mkhomedir
@@ -1,0 +1,8 @@
+Name: Make Home Dir
+Default: yes
+Priority: 96
+
+Session-Type: Additional
+Session-Interactive-Only: yes
+Session:
+  required      pam_mkhomedir.so skel=/etc/skel umask=0022

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'tsmith84@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures LDAP on RHEL/Ubuntu using SSSD'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.1'
+version          '2.0.2'
 
 %w( redhat centos amazon scientific oracle ubuntu debian ).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'tsmith84@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures LDAP on RHEL/Ubuntu using SSSD'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.2'
+version          '2.0.3'
 
 %w( redhat centos amazon scientific oracle ubuntu debian ).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'tsmith84@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures LDAP on RHEL/Ubuntu using SSSD'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.3'
+version          '2.0.4'
 
 %w( redhat centos amazon scientific oracle ubuntu debian ).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -79,7 +79,6 @@ if platform?('ubuntu')
   end
   execute 'pam-auth-update' do
     command "pam-auth-update --package"
-    action :nothing
   end
 end
 
@@ -94,10 +93,6 @@ template '/etc/sssd/sssd.conf' do
     # this needs to run immediately so it doesn't happen after sssd
     # service block below, or sssd won't start when recipe completes
     notifies :run, 'execute[authconfig]', :immediately
-  end
-
-  if platform?('ubuntu')
-    notifies :run, 'execute[pam-auth-config]', :immediately
   end
 
   notifies :restart, 'service[sssd]'

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -14,6 +14,11 @@ filter_users = root,named,avahi,haldaemon,dbus,radiusd,news,nscd
 
 <% if node['sssd_ldap']['ldap_ssh'] %>[ssh]<% end %>
 
+<% if node['sssd_ldap']['domains'].kind_of?(::Hash) %>
+  <% node['sssd_ldap']['domains'].each_key {|dkey| %>
+[domain/<%=dkey%>]
+  <% } %>
+<% else %>
 [domain/LDAP]
 auth_provider = <%= node['sssd_ldap']['auth_provider'] %>
 chpass_provider = <%= node['sssd_ldap']['chpass_provider'] %>
@@ -53,3 +58,5 @@ ldap_access_filter = <%= node['sssd_ldap']['ldap_access_filter'] %>
 <% if node['sssd_ldap']['ldap_user_ssh_public_key'] %>ldap_user_ssh_public_key = <%= node['sssd_ldap']['ldap_user_ssh_public_key'] %><% end %>
 min_id = <%= node['sssd_ldap']['min_id'] %>
 max_id = <%= node['sssd_ldap']['max_id'] %>
+
+<% end %>

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -60,6 +60,11 @@ ldap_default_authtok = <%= node['sssd_ldap']['domains'][dkey]['ldap_default_auth
 <%     elsif node['sssd_ldap']['ldap_default_authtok'] %>
 ldap_default_authtok = <%= node['sssd_ldap']['ldap_default_authtok'] %>
 <%     end %>
+<%     if node['sssd_ldap']['domains'][dkey]['ldap_default_authtok_type'] %>
+ldap_default_authtok_type = <%= node['sssd_ldap']['domains'][dkey]['ldap_default_authtok_type'] %>
+<%     elsif node['sssd_ldap']['ldap_default_authtok_type'] %>
+ldap_default_authtok_type = <%= node['sssd_ldap']['ldap_default_authtok_type'] %>
+<%     end %>
 
 <%     if node['sssd_ldap']['domains'][dkey]['ldap_access_filter'] %>
 access_provider = <%= node['sssd_ldap']['domains'][dkey]['access_provider'] %>
@@ -109,6 +114,7 @@ ldap_group_name = <%= node['sssd_ldap']['ldap_group_name'] %>
 
 <% if node['sssd_ldap']['ldap_default_bind_dn'] %>ldap_default_bind_dn = <%= node['sssd_ldap']['ldap_default_bind_dn'] %><% end %>
 <% if node['sssd_ldap']['ldap_default_authtok'] %>ldap_default_authtok = <%= node['sssd_ldap']['ldap_default_authtok'] %><% end %>
+<% if node['sssd_ldap']['ldap_default_authtok_type'] %>ldap_default_authtok_type = <%= node['sssd_ldap']['ldap_default_authtok_type'] %><% end %>
 
 <% if node['sssd_ldap']['ldap_access_filter'] %>
 access_provider = <%= node['sssd_ldap']['access_provider'] %>

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -17,65 +17,65 @@ filter_users = root,named,avahi,haldaemon,dbus,radiusd,news,nscd
 <% if node['sssd_ldap']['domains'].kind_of?(::Hash) %>
 <%   node['sssd_ldap']['domains'].each_key {|dkey| %>
 [domain/<%=dkey%>]
-auth_provider = <%= node['sssd_ldap']['domains']['auth_provider'] ? node['sssd_ldap']['domains']['auth_provider'] : node['sssd_ldap']['auth_provider'] %>
-chpass_provider = <%= node['sssd_ldap']['domains']['chpass_provider'] ? node['sssd_ldap']['domains']['chpass_provider'] : node['sssd_ldap']['chpass_provider'] %>
-<%     if node['sssd_ldap']['domains']['ldap_sudo'] %>
-sudo_provider = <%= node['sssd_ldap']['domains']['sudo_provider'] %>
+auth_provider = <%= node['sssd_ldap']['domains'][dkey]['auth_provider'] ? node['sssd_ldap']['domains'][dkey]['auth_provider'] : node['sssd_ldap']['auth_provider'] %>
+chpass_provider = <%= node['sssd_ldap']['domains'][dkey]['chpass_provider'] ? node['sssd_ldap']['domains'][dkey]['chpass_provider'] : node['sssd_ldap']['chpass_provider'] %>
+<%     if node['sssd_ldap']['domains'][dkey]['ldap_sudo'] %>
+sudo_provider = <%= node['sssd_ldap']['domains'][dkey]['sudo_provider'] %>
 <%     elsif node['sssd_ldap']['ldap_sudo'] %>
 sudo_provider = <%= node['sssd_ldap']['sudo_provider'] %>
 <%     end %>
-id_provider = <%= node['sssd_ldap']['domains']['id_provider'] ? node['sssd_ldap']['domains']['id_provider'] : node['sssd_ldap']['id_provider'] %>
-cache_credentials = <%= node['sssd_ldap']['domains']['cache_credentials'] ? node['sssd_ldap']['domains']['cache_credentials'] : node['sssd_ldap']['cache_credentials'] %>
-enumerate = <%= node['sssd_ldap']['domains']['enumerate'] ? node['sssd_ldap']['domains']['enumerate'] : node['sssd_ldap']['enumerate'] %>
+id_provider = <%= node['sssd_ldap']['domains'][dkey]['id_provider'] ? node['sssd_ldap']['domains'][dkey]['id_provider'] : node['sssd_ldap']['id_provider'] %>
+cache_credentials = <%= node['sssd_ldap']['domains'][dkey]['cache_credentials'] ? node['sssd_ldap']['domains'][dkey]['cache_credentials'] : node['sssd_ldap']['cache_credentials'] %>
+enumerate = <%= node['sssd_ldap']['domains'][dkey]['enumerate'] ? node['sssd_ldap']['domains'][dkey]['enumerate'] : node['sssd_ldap']['enumerate'] %>
 
-ldap_schema = <%= node['sssd_ldap']['domains']['ldap_schema'] ? node['sssd_ldap']['domains']['ldap_schema'] : node['sssd_ldap']['ldap_schema'] %>
-ldap_uri = <%= node['sssd_ldap']['domains']['ldap_uri'] ? node['sssd_ldap']['domains']['ldap_uri'] : node['sssd_ldap']['ldap_uri'] %>
+ldap_schema = <%= node['sssd_ldap']['domains'][dkey]['ldap_schema'] ? node['sssd_ldap']['domains'][dkey]['ldap_schema'] : node['sssd_ldap']['ldap_schema'] %>
+ldap_uri = <%= node['sssd_ldap']['domains'][dkey]['ldap_uri'] ? node['sssd_ldap']['domains'][dkey]['ldap_uri'] : node['sssd_ldap']['ldap_uri'] %>
 
-ldap_tls_reqcert = <%= node['sssd_ldap']['domains']['ldap_tls_reqcert'] ? node['sssd_ldap']['domains']['ldap_tls_reqcert'] : node['sssd_ldap']['ldap_tls_reqcert'] %>
-ldap_tls_cacert = <%= node['sssd_ldap']['domains']['ldap_tls_cacert'] ? node['sssd_ldap']['domains']['ldap_tls_cacert'] : node['sssd_ldap']['ldap_tls_cacert'] %>
-ldap_id_use_start_tls = <%= node['sssd_ldap']['domains']['ldap_id_use_start_tls'] ? node['sssd_ldap']['domains']['ldap_id_use_start_tls'] : node['sssd_ldap']['ldap_id_use_start_tls'] %>
+ldap_tls_reqcert = <%= node['sssd_ldap']['domains'][dkey]['ldap_tls_reqcert'] ? node['sssd_ldap']['domains'][dkey]['ldap_tls_reqcert'] : node['sssd_ldap']['ldap_tls_reqcert'] %>
+ldap_tls_cacert = <%= node['sssd_ldap']['domains'][dkey]['ldap_tls_cacert'] ? node['sssd_ldap']['domains'][dkey]['ldap_tls_cacert'] : node['sssd_ldap']['ldap_tls_cacert'] %>
+ldap_id_use_start_tls = <%= node['sssd_ldap']['domains'][dkey]['ldap_id_use_start_tls'] ? node['sssd_ldap']['domains'][dkey]['ldap_id_use_start_tls'] : node['sssd_ldap']['ldap_id_use_start_tls'] %>
 
-ldap_search_base = <%= node['sssd_ldap']['domains']['ldap_search_base'] ? node['sssd_ldap']['domains']['ldap_search_base'] : node['sssd_ldap']['ldap_search_base'] %>
-ldap_user_search_base = <%= node['sssd_ldap']['domains']['ldap_user_search_base'] ? node['sssd_ldap']['domains']['ldap_user_search_base'] : node['sssd_ldap']['ldap_user_search_base'] %>
-ldap_user_object_class = <%= node['sssd_ldap']['domains']['ldap_user_object_class'] ? node['sssd_ldap']['domains']['ldap_user_object_class'] : node['sssd_ldap']['ldap_user_object_class'] %>
-ldap_user_name = <%= node['sssd_ldap']['domains']['ldap_user_name'] ? node['sssd_ldap']['domains']['ldap_user_name'] : node['sssd_ldap']['ldap_user_name'] %>
-<%     if node['sssd_ldap']['domains']['override_homedir'] %>
-override_homedir = <%= node['sssd_ldap']['domains']['override_homedir'] %>
+ldap_search_base = <%= node['sssd_ldap']['domains'][dkey]['ldap_search_base'] ? node['sssd_ldap']['domains'][dkey]['ldap_search_base'] : node['sssd_ldap']['ldap_search_base'] %>
+ldap_user_search_base = <%= node['sssd_ldap']['domains'][dkey]['ldap_user_search_base'] ? node['sssd_ldap']['domains'][dkey]['ldap_user_search_base'] : node['sssd_ldap']['ldap_user_search_base'] %>
+ldap_user_object_class = <%= node['sssd_ldap']['domains'][dkey]['ldap_user_object_class'] ? node['sssd_ldap']['domains'][dkey]['ldap_user_object_class'] : node['sssd_ldap']['ldap_user_object_class'] %>
+ldap_user_name = <%= node['sssd_ldap']['domains'][dkey]['ldap_user_name'] ? node['sssd_ldap']['domains'][dkey]['ldap_user_name'] : node['sssd_ldap']['ldap_user_name'] %>
+<%     if node['sssd_ldap']['domains'][dkey]['override_homedir'] %>
+override_homedir = <%= node['sssd_ldap']['domains'][dkey]['override_homedir'] %>
 <%     elsif node['sssd_ldap']['override_homedir'] %>
 override_homedir = <%= node['sssd_ldap']['override_homedir'] %>
 <%     end %>
-shell_fallback = <%= node['sssd_ldap']['domains']['shell_fallback'] ? node['sssd_ldap']['domains']['shell_fallback'] : node['sssd_ldap']['shell_fallback'] %>
+shell_fallback = <%= node['sssd_ldap']['domains'][dkey]['shell_fallback'] ? node['sssd_ldap']['domains'][dkey]['shell_fallback'] : node['sssd_ldap']['shell_fallback'] %>
 
-ldap_group_search_base = <%= node['sssd_ldap']['domains']['ldap_group_search_base'] ? node['sssd_ldap']['domains']['ldap_group_search_base'] : node['sssd_ldap']['ldap_group_search_base'] %>
-ldap_group_object_class = <%= node['sssd_ldap']['domains']['ldap_group_object_class'] ? node['sssd_ldap']['domains']['ldap_group_object_class'] : node['sssd_ldap']['ldap_group_object_class'] %>
-ldap_group_name = <%= node['sssd_ldap']['domains']['ldap_group_name'] ? node['sssd_ldap']['domains']['ldap_group_name'] : node['sssd_ldap']['ldap_group_name'] %>
+ldap_group_search_base = <%= node['sssd_ldap']['domains'][dkey]['ldap_group_search_base'] ? node['sssd_ldap']['domains'][dkey]['ldap_group_search_base'] : node['sssd_ldap']['ldap_group_search_base'] %>
+ldap_group_object_class = <%= node['sssd_ldap']['domains'][dkey]['ldap_group_object_class'] ? node['sssd_ldap']['domains'][dkey]['ldap_group_object_class'] : node['sssd_ldap']['ldap_group_object_class'] %>
+ldap_group_name = <%= node['sssd_ldap']['domains'][dkey]['ldap_group_name'] ? node['sssd_ldap']['domains'][dkey]['ldap_group_name'] : node['sssd_ldap']['ldap_group_name'] %>
 
-<%     if node['sssd_ldap']['domains']['ldap_default_bind_dn'] %>
-ldap_default_bind_dn = <%= node['sssd_ldap']['domains']['ldap_default_bind_dn'] %>
+<%     if node['sssd_ldap']['domains'][dkey]['ldap_default_bind_dn'] %>
+ldap_default_bind_dn = <%= node['sssd_ldap']['domains'][dkey]['ldap_default_bind_dn'] %>
 <%     elsif node['sssd_ldap']['ldap_default_bind_dn'] %>
 ldap_default_bind_dn = <%= node['sssd_ldap']['ldap_default_bind_dn'] %>
 <%     end %>
-<%     if node['sssd_ldap']['domains']['ldap_default_authtok'] %>
-ldap_default_authtok = <%= node['sssd_ldap']['domains']['ldap_default_authtok'] %>
+<%     if node['sssd_ldap']['domains'][dkey]['ldap_default_authtok'] %>
+ldap_default_authtok = <%= node['sssd_ldap']['domains'][dkey]['ldap_default_authtok'] %>
 <%     elsif node['sssd_ldap']['ldap_default_authtok'] %>
 ldap_default_authtok = <%= node['sssd_ldap']['ldap_default_authtok'] %>
 <%     end %>
 
-<%     if node['sssd_ldap']['domains']['ldap_access_filter'] %>
-access_provider = <%= node['sssd_ldap']['domains']['access_provider'] %>
-ldap_access_filter = <%= node['sssd_ldap']['domains']['ldap_access_filter'] %>
+<%     if node['sssd_ldap']['domains'][dkey]['ldap_access_filter'] %>
+access_provider = <%= node['sssd_ldap']['domains'][dkey]['access_provider'] %>
+ldap_access_filter = <%= node['sssd_ldap']['domains'][dkey]['ldap_access_filter'] %>
 <%     elsif node['sssd_ldap']['ldap_access_filter'] %>
 access_provider = <%= node['sssd_ldap']['access_provider'] %>
 ldap_access_filter = <%= node['sssd_ldap']['ldap_access_filter'] %>
 <%     end %>
 
-<%     if node['sssd_ldap']['domains']['ldap_user_ssh_public_key'] %>
-ldap_user_ssh_public_key = <%= node['sssd_ldap']['domains']['ldap_user_ssh_public_key'] %>
+<%     if node['sssd_ldap']['domains'][dkey]['ldap_user_ssh_public_key'] %>
+ldap_user_ssh_public_key = <%= node['sssd_ldap']['domains'][dkey]['ldap_user_ssh_public_key'] %>
 <%     elsif node['sssd_ldap']['ldap_user_ssh_public_key'] %>
 ldap_user_ssh_public_key = <%= node['sssd_ldap']['ldap_user_ssh_public_key'] %>
 <%     end %>
-min_id = <%= node['sssd_ldap']['domains']['min_id'] ? node['sssd_ldap']['domains']['min_id'] : node['sssd_ldap']['min_id'] %>
-max_id = <%= node['sssd_ldap']['domains']['max_id'] ? node['sssd_ldap']['domains']['max_id'] : node['sssd_ldap']['max_id'] %>
+min_id = <%= node['sssd_ldap']['domains'][dkey]['min_id'] ? node['sssd_ldap']['domains'][dkey]['min_id'] : node['sssd_ldap']['min_id'] %>
+max_id = <%= node['sssd_ldap']['domains'][dkey]['max_id'] ? node['sssd_ldap']['domains'][dkey]['max_id'] : node['sssd_ldap']['max_id'] %>
 
   <% } %>
 <% else %>

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -2,7 +2,7 @@
 config_file_version = 2
 services = nss, pam<% if node['sssd_ldap']['ldap_sudo'] %>, sudo<% end %><% if node['sssd_ldap']['ldap_ssh'] %>, ssh<% end %>
 <% if node['sssd_ldap']['domains'].kind_of?(::Hash) %>
-domains = <%=node['sssd_ldap']['domains'].keys.join(",")%>
+domains = LDAP,<%=node['sssd_ldap']['domains'].keys.join(",")%>
 <% else %>
 domains = LDAP
 <% end %>
@@ -13,6 +13,47 @@ filter_users = root,named,avahi,haldaemon,dbus,radiusd,news,nscd
 [pam]
 
 <% if node['sssd_ldap']['ldap_ssh'] %>[ssh]<% end %>
+
+[domain/LDAP]
+auth_provider = <%= node['sssd_ldap']['auth_provider'] %>
+chpass_provider = <%= node['sssd_ldap']['chpass_provider'] %>
+<% if node['sssd_ldap']['ldap_sudo'] %>sudo_provider = <%= node['sssd_ldap']['sudo_provider'] %><% end %>
+id_provider = <%= node['sssd_ldap']['id_provider'] %>
+cache_credentials = <%= node['sssd_ldap']['cache_credentials'] %>
+enumerate = <%= node['sssd_ldap']['enumerate'] %>
+
+ldap_schema = <%= node['sssd_ldap']['ldap_schema'] %>
+ldap_uri = <%= node['sssd_ldap']['ldap_uri'] %>
+
+ldap_tls_reqcert = <%= node['sssd_ldap']['ldap_tls_reqcert'] %>
+ldap_tls_cacert = <%= node['sssd_ldap']['ldap_tls_cacert'] %>
+ldap_id_use_start_tls = <%= node['sssd_ldap']['ldap_id_use_start_tls'] %>
+
+ldap_search_base = <%= node['sssd_ldap']['ldap_search_base'] %>
+ldap_user_search_base = <%= node['sssd_ldap']['ldap_user_search_base'] %>
+ldap_user_object_class = <%= node['sssd_ldap']['ldap_user_object_class'] %>
+ldap_user_name = <%= node['sssd_ldap']['ldap_user_name'] %>
+<% if node['sssd_ldap']['override_homedir'] %>
+override_homedir = <%= node['sssd_ldap']['override_homedir'] %>
+<% end %>
+shell_fallback = <%= node['sssd_ldap']['shell_fallback'] %>
+
+ldap_group_search_base = <%= node['sssd_ldap']['ldap_group_search_base'] %>
+ldap_group_object_class = <%= node['sssd_ldap']['ldap_group_object_class'] %>
+ldap_group_name = <%= node['sssd_ldap']['ldap_group_name'] %>
+
+<% if node['sssd_ldap']['ldap_default_bind_dn'] %>ldap_default_bind_dn = <%= node['sssd_ldap']['ldap_default_bind_dn'] %><% end %>
+<% if node['sssd_ldap']['ldap_default_authtok'] %>ldap_default_authtok = <%= node['sssd_ldap']['ldap_default_authtok'] %><% end %>
+<% if node['sssd_ldap']['ldap_default_authtok_type'] %>ldap_default_authtok_type = <%= node['sssd_ldap']['ldap_default_authtok_type'] %><% end %>
+
+<% if node['sssd_ldap']['ldap_access_filter'] %>
+access_provider = <%= node['sssd_ldap']['access_provider'] %>
+ldap_access_filter = <%= node['sssd_ldap']['ldap_access_filter'] %>
+<% end %>
+
+<% if node['sssd_ldap']['ldap_user_ssh_public_key'] %>ldap_user_ssh_public_key = <%= node['sssd_ldap']['ldap_user_ssh_public_key'] %><% end %>
+min_id = <%= node['sssd_ldap']['min_id'] %>
+max_id = <%= node['sssd_ldap']['max_id'] %>
 
 <% if node['sssd_ldap']['domains'].kind_of?(::Hash) %>
 <%   node['sssd_ldap']['domains'].each_key {|dkey| %>
@@ -83,46 +124,4 @@ min_id = <%= node['sssd_ldap']['domains'][dkey]['min_id'] ? node['sssd_ldap']['d
 max_id = <%= node['sssd_ldap']['domains'][dkey]['max_id'] ? node['sssd_ldap']['domains'][dkey]['max_id'] : node['sssd_ldap']['max_id'] %>
 
   <% } %>
-<% else %>
-[domain/LDAP]
-auth_provider = <%= node['sssd_ldap']['auth_provider'] %>
-chpass_provider = <%= node['sssd_ldap']['chpass_provider'] %>
-<% if node['sssd_ldap']['ldap_sudo'] %>sudo_provider = <%= node['sssd_ldap']['sudo_provider'] %><% end %>
-id_provider = <%= node['sssd_ldap']['id_provider'] %>
-cache_credentials = <%= node['sssd_ldap']['cache_credentials'] %>
-enumerate = <%= node['sssd_ldap']['enumerate'] %>
-
-ldap_schema = <%= node['sssd_ldap']['ldap_schema'] %>
-ldap_uri = <%= node['sssd_ldap']['ldap_uri'] %>
-
-ldap_tls_reqcert = <%= node['sssd_ldap']['ldap_tls_reqcert'] %>
-ldap_tls_cacert = <%= node['sssd_ldap']['ldap_tls_cacert'] %>
-ldap_id_use_start_tls = <%= node['sssd_ldap']['ldap_id_use_start_tls'] %>
-
-ldap_search_base = <%= node['sssd_ldap']['ldap_search_base'] %>
-ldap_user_search_base = <%= node['sssd_ldap']['ldap_user_search_base'] %>
-ldap_user_object_class = <%= node['sssd_ldap']['ldap_user_object_class'] %>
-ldap_user_name = <%= node['sssd_ldap']['ldap_user_name'] %>
-<% if node['sssd_ldap']['override_homedir'] %>
-override_homedir = <%= node['sssd_ldap']['override_homedir'] %>
-<% end %>
-shell_fallback = <%= node['sssd_ldap']['shell_fallback'] %>
-
-ldap_group_search_base = <%= node['sssd_ldap']['ldap_group_search_base'] %>
-ldap_group_object_class = <%= node['sssd_ldap']['ldap_group_object_class'] %>
-ldap_group_name = <%= node['sssd_ldap']['ldap_group_name'] %>
-
-<% if node['sssd_ldap']['ldap_default_bind_dn'] %>ldap_default_bind_dn = <%= node['sssd_ldap']['ldap_default_bind_dn'] %><% end %>
-<% if node['sssd_ldap']['ldap_default_authtok'] %>ldap_default_authtok = <%= node['sssd_ldap']['ldap_default_authtok'] %><% end %>
-<% if node['sssd_ldap']['ldap_default_authtok_type'] %>ldap_default_authtok_type = <%= node['sssd_ldap']['ldap_default_authtok_type'] %><% end %>
-
-<% if node['sssd_ldap']['ldap_access_filter'] %>
-access_provider = <%= node['sssd_ldap']['access_provider'] %>
-ldap_access_filter = <%= node['sssd_ldap']['ldap_access_filter'] %>
-<% end %>
-
-<% if node['sssd_ldap']['ldap_user_ssh_public_key'] %>ldap_user_ssh_public_key = <%= node['sssd_ldap']['ldap_user_ssh_public_key'] %><% end %>
-min_id = <%= node['sssd_ldap']['min_id'] %>
-max_id = <%= node['sssd_ldap']['max_id'] %>
-
 <% end %>

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -1,7 +1,11 @@
 [sssd]
 config_file_version = 2
 services = nss, pam<% if node['sssd_ldap']['ldap_sudo'] %>, sudo<% end %><% if node['sssd_ldap']['ldap_ssh'] %>, ssh<% end %>
+<% if node['sssd_ldap']['domains'].kind_of?(::Hash) %>
+domains = <%=node['ssd_ldap']['domains'].keys.join(",")%>
+<% else %>
 domains = LDAP
+<% end %>
 
 [nss]
 filter_users = root,named,avahi,haldaemon,dbus,radiusd,news,nscd

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -46,5 +46,6 @@ access_provider = <%= node['sssd_ldap']['access_provider'] %>
 ldap_access_filter = <%= node['sssd_ldap']['ldap_access_filter'] %>
 <% end %>
 
+<% if node['sssd_ldap']['ldap_user_ssh_public_key'] %>ldap_user_ssh_public_key = <%= node['sssd_ldap']['ldap_user_ssh_public_key'] %><% end %>
 min_id = <%= node['sssd_ldap']['min_id'] %>
 max_id = <%= node['sssd_ldap']['max_id'] %>

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -2,7 +2,7 @@
 config_file_version = 2
 services = nss, pam<% if node['sssd_ldap']['ldap_sudo'] %>, sudo<% end %><% if node['sssd_ldap']['ldap_ssh'] %>, ssh<% end %>
 <% if node['sssd_ldap']['domains'].kind_of?(::Hash) %>
-domains = <%=node['ssd_ldap']['domains'].keys.join(",")%>
+domains = <%=node['sssd_ldap']['domains'].keys.join(",")%>
 <% else %>
 domains = LDAP
 <% end %>
@@ -17,6 +17,7 @@ filter_users = root,named,avahi,haldaemon,dbus,radiusd,news,nscd
 <% if node['sssd_ldap']['domains'].kind_of?(::Hash) %>
   <% node['sssd_ldap']['domains'].each_key {|dkey| %>
 [domain/<%=dkey%>]
+auth_provider = <%= node['sssd_ldap']['domains']['auth_provider'] ? node['sssd_ldap']['domains']['auth_provider'] : node['sssd_ldap']['auth_provider'] %>
   <% } %>
 <% else %>
 [domain/LDAP]

--- a/templates/default/sssd.conf.erb
+++ b/templates/default/sssd.conf.erb
@@ -15,9 +15,68 @@ filter_users = root,named,avahi,haldaemon,dbus,radiusd,news,nscd
 <% if node['sssd_ldap']['ldap_ssh'] %>[ssh]<% end %>
 
 <% if node['sssd_ldap']['domains'].kind_of?(::Hash) %>
-  <% node['sssd_ldap']['domains'].each_key {|dkey| %>
+<%   node['sssd_ldap']['domains'].each_key {|dkey| %>
 [domain/<%=dkey%>]
 auth_provider = <%= node['sssd_ldap']['domains']['auth_provider'] ? node['sssd_ldap']['domains']['auth_provider'] : node['sssd_ldap']['auth_provider'] %>
+chpass_provider = <%= node['sssd_ldap']['domains']['chpass_provider'] ? node['sssd_ldap']['domains']['chpass_provider'] : node['sssd_ldap']['chpass_provider'] %>
+<%     if node['sssd_ldap']['domains']['ldap_sudo'] %>
+sudo_provider = <%= node['sssd_ldap']['domains']['sudo_provider'] %>
+<%     elsif node['sssd_ldap']['ldap_sudo'] %>
+sudo_provider = <%= node['sssd_ldap']['sudo_provider'] %>
+<%     end %>
+id_provider = <%= node['sssd_ldap']['domains']['id_provider'] ? node['sssd_ldap']['domains']['id_provider'] : node['sssd_ldap']['id_provider'] %>
+cache_credentials = <%= node['sssd_ldap']['domains']['cache_credentials'] ? node['sssd_ldap']['domains']['cache_credentials'] : node['sssd_ldap']['cache_credentials'] %>
+enumerate = <%= node['sssd_ldap']['domains']['enumerate'] ? node['sssd_ldap']['domains']['enumerate'] : node['sssd_ldap']['enumerate'] %>
+
+ldap_schema = <%= node['sssd_ldap']['domains']['ldap_schema'] ? node['sssd_ldap']['domains']['ldap_schema'] : node['sssd_ldap']['ldap_schema'] %>
+ldap_uri = <%= node['sssd_ldap']['domains']['ldap_uri'] ? node['sssd_ldap']['domains']['ldap_uri'] : node['sssd_ldap']['ldap_uri'] %>
+
+ldap_tls_reqcert = <%= node['sssd_ldap']['domains']['ldap_tls_reqcert'] ? node['sssd_ldap']['domains']['ldap_tls_reqcert'] : node['sssd_ldap']['ldap_tls_reqcert'] %>
+ldap_tls_cacert = <%= node['sssd_ldap']['domains']['ldap_tls_cacert'] ? node['sssd_ldap']['domains']['ldap_tls_cacert'] : node['sssd_ldap']['ldap_tls_cacert'] %>
+ldap_id_use_start_tls = <%= node['sssd_ldap']['domains']['ldap_id_use_start_tls'] ? node['sssd_ldap']['domains']['ldap_id_use_start_tls'] : node['sssd_ldap']['ldap_id_use_start_tls'] %>
+
+ldap_search_base = <%= node['sssd_ldap']['domains']['ldap_search_base'] ? node['sssd_ldap']['domains']['ldap_search_base'] : node['sssd_ldap']['ldap_search_base'] %>
+ldap_user_search_base = <%= node['sssd_ldap']['domains']['ldap_user_search_base'] ? node['sssd_ldap']['domains']['ldap_user_search_base'] : node['sssd_ldap']['ldap_user_search_base'] %>
+ldap_user_object_class = <%= node['sssd_ldap']['domains']['ldap_user_object_class'] ? node['sssd_ldap']['domains']['ldap_user_object_class'] : node['sssd_ldap']['ldap_user_object_class'] %>
+ldap_user_name = <%= node['sssd_ldap']['domains']['ldap_user_name'] ? node['sssd_ldap']['domains']['ldap_user_name'] : node['sssd_ldap']['ldap_user_name'] %>
+<%     if node['sssd_ldap']['domains']['override_homedir'] %>
+override_homedir = <%= node['sssd_ldap']['domains']['override_homedir'] %>
+<%     elsif node['sssd_ldap']['override_homedir'] %>
+override_homedir = <%= node['sssd_ldap']['override_homedir'] %>
+<%     end %>
+shell_fallback = <%= node['sssd_ldap']['domains']['shell_fallback'] ? node['sssd_ldap']['domains']['shell_fallback'] : node['sssd_ldap']['shell_fallback'] %>
+
+ldap_group_search_base = <%= node['sssd_ldap']['domains']['ldap_group_search_base'] ? node['sssd_ldap']['domains']['ldap_group_search_base'] : node['sssd_ldap']['ldap_group_search_base'] %>
+ldap_group_object_class = <%= node['sssd_ldap']['domains']['ldap_group_object_class'] ? node['sssd_ldap']['domains']['ldap_group_object_class'] : node['sssd_ldap']['ldap_group_object_class'] %>
+ldap_group_name = <%= node['sssd_ldap']['domains']['ldap_group_name'] ? node['sssd_ldap']['domains']['ldap_group_name'] : node['sssd_ldap']['ldap_group_name'] %>
+
+<%     if node['sssd_ldap']['domains']['ldap_default_bind_dn'] %>
+ldap_default_bind_dn = <%= node['sssd_ldap']['domains']['ldap_default_bind_dn'] %>
+<%     elsif node['sssd_ldap']['ldap_default_bind_dn'] %>
+ldap_default_bind_dn = <%= node['sssd_ldap']['ldap_default_bind_dn'] %>
+<%     end %>
+<%     if node['sssd_ldap']['domains']['ldap_default_authtok'] %>
+ldap_default_authtok = <%= node['sssd_ldap']['domains']['ldap_default_authtok'] %>
+<%     elsif node['sssd_ldap']['ldap_default_authtok'] %>
+ldap_default_authtok = <%= node['sssd_ldap']['ldap_default_authtok'] %>
+<%     end %>
+
+<%     if node['sssd_ldap']['domains']['ldap_access_filter'] %>
+access_provider = <%= node['sssd_ldap']['domains']['access_provider'] %>
+ldap_access_filter = <%= node['sssd_ldap']['domains']['ldap_access_filter'] %>
+<%     elsif node['sssd_ldap']['ldap_access_filter'] %>
+access_provider = <%= node['sssd_ldap']['access_provider'] %>
+ldap_access_filter = <%= node['sssd_ldap']['ldap_access_filter'] %>
+<%     end %>
+
+<%     if node['sssd_ldap']['domains']['ldap_user_ssh_public_key'] %>
+ldap_user_ssh_public_key = <%= node['sssd_ldap']['domains']['ldap_user_ssh_public_key'] %>
+<%     elsif node['sssd_ldap']['ldap_user_ssh_public_key'] %>
+ldap_user_ssh_public_key = <%= node['sssd_ldap']['ldap_user_ssh_public_key'] %>
+<%     end %>
+min_id = <%= node['sssd_ldap']['domains']['min_id'] ? node['sssd_ldap']['domains']['min_id'] : node['sssd_ldap']['min_id'] %>
+max_id = <%= node['sssd_ldap']['domains']['max_id'] ? node['sssd_ldap']['domains']['max_id'] : node['sssd_ldap']['max_id'] %>
+
   <% } %>
 <% else %>
 [domain/LDAP]


### PR DESCRIPTION
Ubuntu, at least, requires me to specify the ldap_user_ssh_public_key attribute in the sssd.conf file in order for the ssh key functionality to work.
